### PR TITLE
Fix `default_branch` reference

### DIFF
--- a/.github/workflows/ref.yml
+++ b/.github/workflows/ref.yml
@@ -14,7 +14,7 @@ jobs:
   foo:
     runs-on: ubuntu-latest
     env:
-      DEFAULT_BRANCH: ${{ github.repository.default_branch }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       REF: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`github.repository` is a string: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context